### PR TITLE
Stream binary audio data

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -230,12 +230,9 @@ socket.on('videoFrame:rearCamera', data => {
 //     dotblinker.classList.toggle('bg-green-500')
 // })
 
-socket.on('audio', base64 => {
+socket.on('audio', chunk => {
     try {
-        const binary = atob(base64);
-        const bytes = new Uint8Array(binary.length);
-        for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
-        player.feed(new Int16Array(bytes.buffer));
+        player.feed(new Int16Array(chunk));
         player.flush();
     } catch (err) {
         console.error('Error processing audio:', err);

--- a/server.js
+++ b/server.js
@@ -333,7 +333,7 @@ function startAudioStream() {
     ]);
 
     audio.stdout.on('data', (data) => {
-        io.emit('audio', data.toString('base64'));
+        io.emit('audio', data);
     });
 
     audio.stderr.on('data', (data) => {


### PR DESCRIPTION
## Summary
- Emit raw audio buffers to clients instead of base64 strings for more efficient streaming.
- Feed received audio chunks directly into PCMPlayer without base64 decoding.

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ba46a12e70832784286707f31e12af