### PR TITLE
Send video frames as binary buffers over socket.io

### DIFF
--- a/CameraStream.js
+++ b/CameraStream.js
@@ -55,9 +55,11 @@ class CameraStream {
             if (this.latestFrame) {
                 const frameToSend = this.latestFrame;
                 this.latestFrame = null;
-                this.io.emit(`videoFrame:${this.cameraId}`, frameToSend.toString('base64'));
+                // Send raw JPEG buffer instead of base64 for efficiency
+                this.io.emit(`videoFrame:${this.cameraId}`, frameToSend);
                 if (this.cameraId === 'frontCamera') {
-                    latestFrontFrame = frameToSend.toString('base64');
+                    // Store latest frame as buffer for optional consumers
+                    latestFrontFrame = frameToSend;
                 }
             }
         }, this.interval);
@@ -94,5 +96,6 @@ class CameraStream {
 
 module.exports = {
     CameraStream,
-    getLatestFrontFrame: () => latestFrontFrame,
+    // Convert stored buffer to base64 on demand for compatibility
+    getLatestFrontFrame: () => (latestFrontFrame ? latestFrontFrame.toString('base64') : null),
 }

--- a/public/main.js
+++ b/public/main.js
@@ -214,15 +214,25 @@ function easyDock() { socket.emit('easyDock'); }
 const dotblinker = document.getElementById('blinker');
 dotblinker.classList.toggle('bg-red-500')
 
+// Track object URLs so they can be revoked and avoid memory leaks
+let frontVideoUrl = null;
+let rearVideoUrl = null;
+
 socket.on('videoFrame:frontCamera', data => {
-    document.getElementById('video').src = 'data:image/jpeg;base64,' + data;       
-    
+    const blob = new Blob([data], { type: 'image/jpeg' });
+    if (frontVideoUrl) URL.revokeObjectURL(frontVideoUrl);
+    frontVideoUrl = URL.createObjectURL(blob);
+    document.getElementById('video').src = frontVideoUrl;
+
     dotblinker.classList.toggle('bg-red-500')
     dotblinker.classList.toggle('bg-green-500')
 });
 
 socket.on('videoFrame:rearCamera', data => {
-    document.getElementById('rearvideo').src = 'data:image/jpeg;base64,' + data;
+    const blob = new Blob([data], { type: 'image/jpeg' });
+    if (rearVideoUrl) URL.revokeObjectURL(rearVideoUrl);
+    rearVideoUrl = URL.createObjectURL(blob);
+    document.getElementById('rearvideo').src = rearVideoUrl;
 })
 
 // socket.on('videoFrame', () => {

--- a/public/old-index.html
+++ b/public/old-index.html
@@ -122,20 +122,17 @@
         }
 
         // video and audio handlers
-        socket.on('videoFrame', function(data) {
-            document.getElementById('video').src = 'data:image/jpeg;base64,' + data;
+        let videoUrl = null;
+        socket.on('videoFrame:frontCamera', function(data) {
+            const blob = new Blob([data], { type: 'image/jpeg' });
+            if (videoUrl) URL.revokeObjectURL(videoUrl);
+            videoUrl = URL.createObjectURL(blob);
+            document.getElementById('video').src = videoUrl;
         });
 
-        socket.on('audio', function(base64) {
+        socket.on('audio', function(chunk) {
             try {
-                const binary = atob(base64);
-                const len = binary.length;
-                const bytes = new Uint8Array(len);
-                for (let i = 0; i < len; i++) {
-                    bytes[i] = binary.charCodeAt(i);
-                }
-                const buffer = new Int16Array(bytes.buffer);
-                player.feed(buffer);
+                player.feed(new Int16Array(chunk));
                 player.flush();
             } catch (err) {
                 console.error('Error processing audio chunk:', err);


### PR DESCRIPTION
## Summary
- Stream JPEG frames as binary buffers instead of base64 for lower bandwidth and CPU use
- Handle binary video frames on clients via Blob URLs and revoke previous URLs
- Update legacy client and audio handler to work with binary data

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ba5828890c832788fb3dabea86dbb8