### PR TITLE
Add system resource monitor to UI

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -186,6 +186,8 @@
                     <p id="battery-voltage" class="p-1 bg-gray-500 rounded">No Data</p>
                     <p id="brush-current" class="p-1 bg-gray-500 rounded">No Data</p>
                     <p id="battery-current" class="p-1 bg-gray-500 rounded">No Data</p>
+                    <p id="cpu-usage" class="p-1 bg-gray-500 rounded">CPU: --%</p>
+                    <p id="memory-usage" class="p-1 bg-gray-500 rounded">RAM: --%</p>
                 </div>
             </div>
 

--- a/public/main.js
+++ b/public/main.js
@@ -6,13 +6,15 @@ dockStatus: document.getElementById('dock-status'),
 chargeStatus: document.getElementById('charge-status'),
 batteryUsage: document.getElementById('battery-usage'),
 batteryVoltage: document.getElementById('battery-voltage'),
-brushCurrent: document.getElementById('brush-current'),
-batteryCurrent: document.getElementById('battery-current'),
-bumpSensors: {
-    L: document.getElementById('lightbump-L'),
-    FL: document.getElementById('lightbump-FL'),
-    CL: document.getElementById('lightbump-CL'),
-    CR: document.getElementById('lightbump-CR'),
+    brushCurrent: document.getElementById('brush-current'),
+    batteryCurrent: document.getElementById('battery-current'),
+    cpuUsage: document.getElementById('cpu-usage'),
+    memoryUsage: document.getElementById('memory-usage'),
+    bumpSensors: {
+        L: document.getElementById('lightbump-L'),
+        FL: document.getElementById('lightbump-FL'),
+        CL: document.getElementById('lightbump-CL'),
+        CR: document.getElementById('lightbump-CR'),
     FR: document.getElementById('lightbump-FR'),
     R: document.getElementById('lightbump-R')
 },
@@ -105,6 +107,11 @@ socket.on('disconnect', () => {
     document.getElementById('connectstatus').innerText = 'Disconnected'
     document.getElementById('connectstatus').classList.remove('bg-green-500')
     document.getElementById('connectstatus').classList.add('bg-red-500')
+});
+
+socket.on('system-stats', data => {
+    dom.cpuUsage.textContent = `CPU: ${data.cpu}%`;
+    dom.memoryUsage.textContent = `RAM: ${data.memory}%`;
 });
 
 // key handler function


### PR DESCRIPTION
## Summary
- Show server CPU and RAM usage on the control panel
- Broadcast lightweight system stats only when clients are connected
- Keep bumpSensors array limited to the six front light sensors

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ba5e82fac883278e1e8ea06299b500