### PR TITLE
Add wheel encoder support and visualization

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -98,19 +98,31 @@
 
                     <div id="blinker" class="absolute top-3 right-3 w-5 h-5 rounded-full bg-green-500 bg-red-500 opacity-50"></div>
                     <div id="sensorblinker" class="p-1 rounded-full bg-pink-400 bg-black w-5 h-5 absolute right-10 top-3 opacity-50"></div>
-                    
+
                     <!-- <div class="p-1 bg-red-300 h-5 w-1/2 absolute right-3 bottom-10">
                         <div class="h-full bg-green-500" style="width: 0%;" id="wall-distance"></div>
                     </div> -->
 
-                    <!-- <div class="absolute bottom-3 left-3 bg-gray-500"> -->
-                        <div class="absolute bottom-3 left-3 w-5 h-10 bg-gray-500 items-start rounded-full opacity-50 overflow-hidden" data-help="Left Motor Current">
-                            <div class="bg-green-500 opactiy-50" style="height: 0%;" id="leftCurrent-bar"></div>
+                    <div id="motor-encoder-overlay" class="absolute bottom-3 left-3 flex gap-2 p-1 rounded-md text-xs text-white" style="background-color: rgba(107,114,128,0.5);">
+                        <div class="flex flex-col items-center" data-help="Left Motor">
+                            <div class="w-3 h-10 bg-gray-800 rounded-full overflow-hidden">
+                                <div id="leftCurrent-bar" class="bg-green-500 w-full" style="height: 0%;"></div>
+                            </div>
+                            <div class="w-8 h-1 bg-gray-800 rounded overflow-hidden mt-1">
+                                <div id="encoder-left-bar" class="h-full bg-purple-500" style="width: 0%;"></div>
+                            </div>
+                            <p id="encoder-left-text" class="mt-1">L 0</p>
                         </div>
-                        <div class="absolute bottom-3 left-10 w-5 h-10 bg-gray-500 items-start opacity-50 rounded-full overflow-hidden" data-help="Right Motor Current">
-                            <div class="bg-green-500 opactiy-50" style="height: 0%;" id="rightCurrent-bar"></div>
+                        <div class="flex flex-col items-center" data-help="Right Motor">
+                            <div class="w-3 h-10 bg-gray-800 rounded-full overflow-hidden">
+                                <div id="rightCurrent-bar" class="bg-green-500 w-full" style="height: 0%;"></div>
+                            </div>
+                            <div class="w-8 h-1 bg-gray-800 rounded overflow-hidden mt-1">
+                                <div id="encoder-right-bar" class="h-full bg-purple-500" style="width: 0%;"></div>
+                            </div>
+                            <p id="encoder-right-text" class="mt-1">R 0</p>
                         </div>
-                    <!-- </div> -->
+                    </div>
 
                     <p id="connectstatus" class="absolute top-3 left-3 rounded-full bg-red-500 bg-green-500 p-2 opacity-50">Disconnected</p>
                     <video id="localcam" class="absolute top-3 left-1/2 rounded-md w-40" autoplay muted></video>
@@ -178,15 +190,6 @@
                 </div>
 
 
-                <div id="encoder-bars" class="flex gap-1 text-xs md:text-base relative mt-1" data-help="Wheel Encoder Movement">
-                    <div class="w-1/2 h-5 bg-gray-500 flex items-end rounded overflow-hidden">
-                        <div id="encoder-left-bar" class="h-full bg-purple-500" style="width: 0%"></div>
-                    </div>
-                    <div class="w-1/2 h-5 bg-gray-500 flex items-end rounded overflow-hidden">
-                        <div id="encoder-right-bar" class="h-full bg-purple-500" style="width: 0%"></div>
-                    </div>
-                </div>
-
                 <div id="sensor-data" class="flex flex-wrap gap-1 text-xs md:text-base relative mt-1">
                     <p id="charge-status" class="p-1 bg-gray-500 rounded">No Data</p>
                     <p id="battery-usage" class="p-1 bg-gray-500 rounded">No Data</p>
@@ -197,8 +200,6 @@
                     <p id="battery-current" class="p-1 bg-gray-500 rounded">No Data</p>
                     <p id="cpu-usage" class="p-1 bg-gray-500 rounded">No Data</p>
                     <p id="memory-usage" class="p-1 bg-gray-500 rounded">No Data</p>
-                    <p id="encoder-left-text" class="p-1 bg-gray-500 rounded">L Enc: 0</p>
-                    <p id="encoder-right-text" class="p-1 bg-gray-500 rounded">R Enc: 0</p>
                 </div>
             </div>
 

--- a/public/index.html
+++ b/public/index.html
@@ -176,7 +176,16 @@
                         <div id="cliff-R" class="w-full bg-yellow-500" style="height: 0%"></div>
                     </div>
                 </div>
-                  
+
+
+                <div id="encoder-bars" class="flex gap-1 text-xs md:text-base relative mt-1" data-help="Wheel Encoder Movement">
+                    <div class="w-1/2 h-5 bg-gray-500 flex items-end rounded overflow-hidden">
+                        <div id="encoder-left-bar" class="h-full bg-purple-500" style="width: 0%"></div>
+                    </div>
+                    <div class="w-1/2 h-5 bg-gray-500 flex items-end rounded overflow-hidden">
+                        <div id="encoder-right-bar" class="h-full bg-purple-500" style="width: 0%"></div>
+                    </div>
+                </div>
 
                 <div id="sensor-data" class="flex flex-wrap gap-1 text-xs md:text-base relative mt-1">
                     <p id="charge-status" class="p-1 bg-gray-500 rounded">No Data</p>
@@ -188,6 +197,8 @@
                     <p id="battery-current" class="p-1 bg-gray-500 rounded">No Data</p>
                     <p id="cpu-usage" class="p-1 bg-gray-500 rounded">No Data</p>
                     <p id="memory-usage" class="p-1 bg-gray-500 rounded">No Data</p>
+                    <p id="encoder-left-text" class="p-1 bg-gray-500 rounded">L Enc: 0</p>
+                    <p id="encoder-right-text" class="p-1 bg-gray-500 rounded">R Enc: 0</p>
                 </div>
             </div>
 

--- a/public/index.html
+++ b/public/index.html
@@ -104,21 +104,17 @@
                     </div> -->
 
                     <div id="motor-encoder-overlay" class="absolute bottom-3 left-3 flex gap-2 p-1 rounded-md text-xs text-white" style="background-color: rgba(107,114,128,0.5);">
-                        <div class="flex flex-col items-center" data-help="Left Motor">
-                            <div class="w-3 h-10 bg-gray-800 rounded-full overflow-hidden">
-                                <div id="leftCurrent-bar" class="bg-green-500 w-full" style="height: 0%;"></div>
-                            </div>
-                            <div class="w-8 h-1 bg-gray-800 rounded overflow-hidden mt-1">
-                                <div id="encoder-left-bar" class="h-full bg-purple-500" style="width: 0%;"></div>
-                            </div>
+                        <div class="w-3 h-10 bg-gray-800 rounded-full overflow-hidden" data-help="Left Motor Current">
+                            <div id="leftCurrent-bar" class="bg-green-500 w-full" style="height: 0%;"></div>
                         </div>
-                        <div class="flex flex-col items-center" data-help="Right Motor">
-                            <div class="w-3 h-10 bg-gray-800 rounded-full overflow-hidden">
-                                <div id="rightCurrent-bar" class="bg-green-500 w-full" style="height: 0%;"></div>
-                            </div>
-                            <div class="w-8 h-1 bg-gray-800 rounded overflow-hidden mt-1">
-                                <div id="encoder-right-bar" class="h-full bg-purple-500" style="width: 0%;"></div>
-                            </div>
+                        <div class="w-3 h-10 bg-gray-800 rounded-full overflow-hidden" data-help="Left Wheel Delta">
+                            <div id="encoder-left-bar" class="bg-purple-500 w-full" style="height: 0%;"></div>
+                        </div>
+                        <div class="w-3 h-10 bg-gray-800 rounded-full overflow-hidden" data-help="Right Wheel Delta">
+                            <div id="encoder-right-bar" class="bg-purple-500 w-full" style="height: 0%;"></div>
+                        </div>
+                        <div class="w-3 h-10 bg-gray-800 rounded-full overflow-hidden" data-help="Right Motor Current">
+                            <div id="rightCurrent-bar" class="bg-green-500 w-full" style="height: 0%;"></div>
                         </div>
                     </div>
 

--- a/public/index.html
+++ b/public/index.html
@@ -103,15 +103,9 @@
                         <div class="h-full bg-green-500" style="width: 0%;" id="wall-distance"></div>
                     </div> -->
 
-                    <div id="motor-encoder-overlay" class="absolute bottom-3 left-3 flex gap-2 p-1 rounded-md text-xs text-white" style="background-color: rgba(107,114,128,0.5);">
+                    <div id="motor-overlay" class="absolute bottom-3 left-3 flex gap-2 p-1 rounded-md text-xs text-white" style="background-color: rgba(107,114,128,0.5);">
                         <div class="w-3 h-10 bg-gray-800 rounded-full overflow-hidden" data-help="Left Motor Current">
                             <div id="leftCurrent-bar" class="bg-green-500 w-full" style="height: 0%;"></div>
-                        </div>
-                        <div class="w-3 h-10 bg-gray-800 rounded-full overflow-hidden" data-help="Left Wheel Delta">
-                            <div id="encoder-left-bar" class="bg-purple-500 w-full" style="height: 0%;"></div>
-                        </div>
-                        <div class="w-3 h-10 bg-gray-800 rounded-full overflow-hidden" data-help="Right Wheel Delta">
-                            <div id="encoder-right-bar" class="bg-purple-500 w-full" style="height: 0%;"></div>
                         </div>
                         <div class="w-3 h-10 bg-gray-800 rounded-full overflow-hidden" data-help="Right Motor Current">
                             <div id="rightCurrent-bar" class="bg-green-500 w-full" style="height: 0%;"></div>
@@ -192,6 +186,8 @@
                     <p id="battery-voltage" class="p-1 bg-gray-500 rounded">No Data</p>
                     <p id="brush-current" class="p-1 bg-gray-500 rounded">No Data</p>
                     <p id="battery-current" class="p-1 bg-gray-500 rounded">No Data</p>
+                    <p id="left-encoder" class="p-1 bg-gray-500 rounded">No Data</p>
+                    <p id="right-encoder" class="p-1 bg-gray-500 rounded">No Data</p>
                     <p id="cpu-usage" class="p-1 bg-gray-500 rounded">No Data</p>
                     <p id="memory-usage" class="p-1 bg-gray-500 rounded">No Data</p>
                 </div>

--- a/public/index.html
+++ b/public/index.html
@@ -111,7 +111,6 @@
                             <div class="w-8 h-1 bg-gray-800 rounded overflow-hidden mt-1">
                                 <div id="encoder-left-bar" class="h-full bg-purple-500" style="width: 0%;"></div>
                             </div>
-                            <p id="encoder-left-text" class="mt-1">L 0</p>
                         </div>
                         <div class="flex flex-col items-center" data-help="Right Motor">
                             <div class="w-3 h-10 bg-gray-800 rounded-full overflow-hidden">
@@ -120,7 +119,6 @@
                             <div class="w-8 h-1 bg-gray-800 rounded overflow-hidden mt-1">
                                 <div id="encoder-right-bar" class="h-full bg-purple-500" style="width: 0%;"></div>
                             </div>
-                            <p id="encoder-right-text" class="mt-1">R 0</p>
                         </div>
                     </div>
 

--- a/public/main.js
+++ b/public/main.js
@@ -304,14 +304,18 @@ socket.on('SensorData', data => {
     const rightDelta = ((data.rightEncoder - lastEncoders.right + 32768) % 65536) - 32768;
     lastEncoders.left = data.leftEncoder;
     lastEncoders.right = data.rightEncoder;
+
     const leftMag = Math.min(Math.abs(leftDelta), MAX_VALUE_ENCODER_DELTA);
     const rightMag = Math.min(Math.abs(rightDelta), MAX_VALUE_ENCODER_DELTA);
     dom.encoderLeftBar.style.height = `${leftMag / MAX_VALUE_ENCODER_DELTA * 100}%`;
     dom.encoderRightBar.style.height = `${rightMag / MAX_VALUE_ENCODER_DELTA * 100}%`;
-    dom.encoderLeftBar.classList.toggle('bg-orange-500', leftDelta < 0);
-    dom.encoderLeftBar.classList.toggle('bg-purple-500', leftDelta >= 0);
-    dom.encoderRightBar.classList.toggle('bg-orange-500', rightDelta < 0);
-    dom.encoderRightBar.classList.toggle('bg-purple-500', rightDelta >= 0);
+
+    const leftDir = leftDelta !== 0 ? Math.sign(leftDelta) : Math.sign(data.leftCurrent);
+    const rightDir = rightDelta !== 0 ? Math.sign(rightDelta) : Math.sign(data.rightCurrent);
+    dom.encoderLeftBar.classList.toggle('bg-orange-500', leftDir < 0);
+    dom.encoderLeftBar.classList.toggle('bg-purple-500', leftDir >= 0);
+    dom.encoderRightBar.classList.toggle('bg-orange-500', rightDir < 0);
+    dom.encoderRightBar.classList.toggle('bg-purple-500', rightDir >= 0);
 
 
     if(oiMode === 'Full') {

--- a/public/main.js
+++ b/public/main.js
@@ -305,13 +305,17 @@ socket.on('SensorData', data => {
     lastEncoders.left = data.leftEncoder;
     lastEncoders.right = data.rightEncoder;
 
-    const leftMag = Math.min(Math.abs(leftDelta), MAX_VALUE_ENCODER_DELTA);
-    const rightMag = Math.min(Math.abs(rightDelta), MAX_VALUE_ENCODER_DELTA);
+    const leftDeltaMag = Math.abs(leftDelta);
+    const rightDeltaMag = Math.abs(rightDelta);
+    const leftCurrentScaled = leftCurrMag / (MAX_VALUE_WCURRENT / MAX_VALUE_ENCODER_DELTA);
+    const rightCurrentScaled = rightCurrMag / (MAX_VALUE_WCURRENT / MAX_VALUE_ENCODER_DELTA);
+    const leftMag = Math.min(leftDeltaMag || leftCurrentScaled, MAX_VALUE_ENCODER_DELTA);
+    const rightMag = Math.min(rightDeltaMag || rightCurrentScaled, MAX_VALUE_ENCODER_DELTA);
     dom.encoderLeftBar.style.height = `${leftMag / MAX_VALUE_ENCODER_DELTA * 100}%`;
     dom.encoderRightBar.style.height = `${rightMag / MAX_VALUE_ENCODER_DELTA * 100}%`;
 
-    const leftDir = leftDelta !== 0 ? Math.sign(leftDelta) : Math.sign(data.leftCurrent);
-    const rightDir = rightDelta !== 0 ? Math.sign(rightDelta) : Math.sign(data.rightCurrent);
+    const leftDir = leftDeltaMag !== 0 ? Math.sign(leftDelta) : Math.sign(data.leftCurrent);
+    const rightDir = rightDeltaMag !== 0 ? Math.sign(rightDelta) : Math.sign(data.rightCurrent);
     dom.encoderLeftBar.classList.toggle('bg-orange-500', leftDir < 0);
     dom.encoderLeftBar.classList.toggle('bg-purple-500', leftDir >= 0);
     dom.encoderRightBar.classList.toggle('bg-orange-500', rightDir < 0);

--- a/public/main.js
+++ b/public/main.js
@@ -307,15 +307,13 @@ socket.on('SensorData', data => {
 
     const leftDeltaMag = Math.abs(leftDelta);
     const rightDeltaMag = Math.abs(rightDelta);
-    const leftCurrentScaled = leftCurrMag / (MAX_VALUE_WCURRENT / MAX_VALUE_ENCODER_DELTA);
-    const rightCurrentScaled = rightCurrMag / (MAX_VALUE_WCURRENT / MAX_VALUE_ENCODER_DELTA);
-    const leftMag = Math.min(leftDeltaMag || leftCurrentScaled, MAX_VALUE_ENCODER_DELTA);
-    const rightMag = Math.min(rightDeltaMag || rightCurrentScaled, MAX_VALUE_ENCODER_DELTA);
+    const leftMag = Math.min(leftDeltaMag, MAX_VALUE_ENCODER_DELTA);
+    const rightMag = Math.min(rightDeltaMag, MAX_VALUE_ENCODER_DELTA);
     dom.encoderLeftBar.style.height = `${leftMag / MAX_VALUE_ENCODER_DELTA * 100}%`;
     dom.encoderRightBar.style.height = `${rightMag / MAX_VALUE_ENCODER_DELTA * 100}%`;
 
-    const leftDir = leftDeltaMag !== 0 ? Math.sign(leftDelta) : Math.sign(data.leftCurrent);
-    const rightDir = rightDeltaMag !== 0 ? Math.sign(rightDelta) : Math.sign(data.rightCurrent);
+    const leftDir = Math.sign(leftDelta);
+    const rightDir = Math.sign(rightDelta);
     dom.encoderLeftBar.classList.toggle('bg-orange-500', leftDir < 0);
     dom.encoderLeftBar.classList.toggle('bg-purple-500', leftDir >= 0);
     dom.encoderRightBar.classList.toggle('bg-orange-500', rightDir < 0);

--- a/public/main.js
+++ b/public/main.js
@@ -296,8 +296,8 @@ socket.on('SensorData', data => {
     dom.cliffSensors.FR.style.height=`${(data.cliffSensors[2] / MAX_VALUE_CLIFF) * 100}%`
     dom.cliffSensors.R.style.height=`${(data.cliffSensors[3] / MAX_VALUE_CLIFF) * 100}%`
 
-    dom.encoderLeftText.textContent = `L Enc: ${data.leftEncoder}`;
-    dom.encoderRightText.textContent = `R Enc: ${data.rightEncoder}`;
+    dom.encoderLeftText.textContent = `L ${data.leftEncoder}`;
+    dom.encoderRightText.textContent = `R ${data.rightEncoder}`;
     const leftDelta = ((data.leftEncoder - lastEncoders.left + 32768) % 65536) - 32768;
     const rightDelta = ((data.rightEncoder - lastEncoders.right + 32768) % 65536) - 32768;
     lastEncoders.left = data.leftEncoder;

--- a/public/main.js
+++ b/public/main.js
@@ -286,8 +286,14 @@ socket.on('SensorData', data => {
 
     // console.log('Wall signal:', data.wallSignal);
     // dom.wallSignal.style.width = `${(data.wallSignal / MAX_VALUE) * 100}%`;
-    dom.leftCurrentBar.style.height = `${(data.leftCurrent / MAX_VALUE_WCURRENT) * 100}%`;
-    dom.rightCurrentBar.style.height = `${(data.rightCurrent / MAX_VALUE_WCURRENT) * 100}%`;
+    const leftCurrMag = Math.min(Math.abs(data.leftCurrent), MAX_VALUE_WCURRENT);
+    const rightCurrMag = Math.min(Math.abs(data.rightCurrent), MAX_VALUE_WCURRENT);
+    dom.leftCurrentBar.style.height = `${leftCurrMag / MAX_VALUE_WCURRENT * 100}%`;
+    dom.rightCurrentBar.style.height = `${rightCurrMag / MAX_VALUE_WCURRENT * 100}%`;
+    dom.leftCurrentBar.classList.toggle('bg-red-500', data.leftCurrent < 0);
+    dom.leftCurrentBar.classList.toggle('bg-green-500', data.leftCurrent >= 0);
+    dom.rightCurrentBar.classList.toggle('bg-red-500', data.rightCurrent < 0);
+    dom.rightCurrentBar.classList.toggle('bg-green-500', data.rightCurrent >= 0);
 
     dom.cliffSensors.L.style.height=`${(data.cliffSensors[0] / MAX_VALUE_CLIFF) * 100}%`
     dom.cliffSensors.FL.style.height=`${(data.cliffSensors[1] / MAX_VALUE_CLIFF) * 100}%`
@@ -300,8 +306,8 @@ socket.on('SensorData', data => {
     lastEncoders.right = data.rightEncoder;
     const leftMag = Math.min(Math.abs(leftDelta), MAX_VALUE_ENCODER_DELTA);
     const rightMag = Math.min(Math.abs(rightDelta), MAX_VALUE_ENCODER_DELTA);
-    dom.encoderLeftBar.style.width = `${leftMag / MAX_VALUE_ENCODER_DELTA * 100}%`;
-    dom.encoderRightBar.style.width = `${rightMag / MAX_VALUE_ENCODER_DELTA * 100}%`;
+    dom.encoderLeftBar.style.height = `${leftMag / MAX_VALUE_ENCODER_DELTA * 100}%`;
+    dom.encoderRightBar.style.height = `${rightMag / MAX_VALUE_ENCODER_DELTA * 100}%`;
     dom.encoderLeftBar.classList.toggle('bg-orange-500', leftDelta < 0);
     dom.encoderLeftBar.classList.toggle('bg-purple-500', leftDelta >= 0);
     dom.encoderRightBar.classList.toggle('bg-orange-500', rightDelta < 0);

--- a/public/main.js
+++ b/public/main.js
@@ -28,8 +28,6 @@ leftCurrentBar: document.getElementById('leftCurrent-bar'),
 rightCurrentBar: document.getElementById('rightCurrent-bar'),
 encoderLeftBar: document.getElementById('encoder-left-bar'),
 encoderRightBar: document.getElementById('encoder-right-bar'),
-encoderLeftText: document.getElementById('encoder-left-text'),
-encoderRightText: document.getElementById('encoder-right-text'),
 startButtonMessage: document.getElementById('start-button-message'),
 dockButtonMessage: document.getElementById('dock-button-message'),
 dockButtonChargingMessage: document.getElementById('dock-button-charging-message'),
@@ -267,7 +265,7 @@ sensorblinker.classList.toggle('bg-pink-400')
 var MAX_VALUE = 300
 var MAX_VALUE_WCURRENT = 800
 var MAX_VALUE_CLIFF = 2700
-var MAX_VALUE_ENCODER_DELTA = 500
+var MAX_VALUE_ENCODER_DELTA = 50
 let lastEncoders = { left: 0, right: 0 }
 socket.on('SensorData', data => {
     const chargeStatus = ['Not Charging', 'Reconditioning Charging', 'Full Charging', 'Trickle Charging', 'Waiting', 'Charging Error'][data.chargeStatus] || 'Unknown';
@@ -296,8 +294,6 @@ socket.on('SensorData', data => {
     dom.cliffSensors.FR.style.height=`${(data.cliffSensors[2] / MAX_VALUE_CLIFF) * 100}%`
     dom.cliffSensors.R.style.height=`${(data.cliffSensors[3] / MAX_VALUE_CLIFF) * 100}%`
 
-    dom.encoderLeftText.textContent = `L ${data.leftEncoder}`;
-    dom.encoderRightText.textContent = `R ${data.rightEncoder}`;
     const leftDelta = ((data.leftEncoder - lastEncoders.left + 32768) % 65536) - 32768;
     const rightDelta = ((data.rightEncoder - lastEncoders.right + 32768) % 65536) - 32768;
     lastEncoders.left = data.leftEncoder;

--- a/public/main.js
+++ b/public/main.js
@@ -26,8 +26,8 @@ cliffSensors: {
 },
 leftCurrentBar: document.getElementById('leftCurrent-bar'),
 rightCurrentBar: document.getElementById('rightCurrent-bar'),
-encoderLeftBar: document.getElementById('encoder-left-bar'),
-encoderRightBar: document.getElementById('encoder-right-bar'),
+leftEncoder: document.getElementById('left-encoder'),
+rightEncoder: document.getElementById('right-encoder'),
 startButtonMessage: document.getElementById('start-button-message'),
 dockButtonMessage: document.getElementById('dock-button-message'),
 dockButtonChargingMessage: document.getElementById('dock-button-charging-message'),
@@ -265,8 +265,6 @@ sensorblinker.classList.toggle('bg-pink-400')
 var MAX_VALUE = 300
 var MAX_VALUE_WCURRENT = 800
 var MAX_VALUE_CLIFF = 2700
-var MAX_VALUE_ENCODER_DELTA = 50
-let lastEncoders = { left: 0, right: 0 }
 socket.on('SensorData', data => {
     const chargeStatus = ['Not Charging', 'Reconditioning Charging', 'Full Charging', 'Trickle Charging', 'Waiting', 'Charging Error'][data.chargeStatus] || 'Unknown';
     const chargingSources = data.chargingSources === 2 ? 'Docked' : 'None';
@@ -299,25 +297,8 @@ socket.on('SensorData', data => {
     dom.cliffSensors.FL.style.height=`${(data.cliffSensors[1] / MAX_VALUE_CLIFF) * 100}%`
     dom.cliffSensors.FR.style.height=`${(data.cliffSensors[2] / MAX_VALUE_CLIFF) * 100}%`
     dom.cliffSensors.R.style.height=`${(data.cliffSensors[3] / MAX_VALUE_CLIFF) * 100}%`
-
-    const leftDelta = ((data.leftEncoder - lastEncoders.left + 32768) % 65536) - 32768;
-    const rightDelta = ((data.rightEncoder - lastEncoders.right + 32768) % 65536) - 32768;
-    lastEncoders.left = data.leftEncoder;
-    lastEncoders.right = data.rightEncoder;
-
-    const leftDeltaMag = Math.abs(leftDelta);
-    const rightDeltaMag = Math.abs(rightDelta);
-    const leftMag = Math.min(leftDeltaMag, MAX_VALUE_ENCODER_DELTA);
-    const rightMag = Math.min(rightDeltaMag, MAX_VALUE_ENCODER_DELTA);
-    dom.encoderLeftBar.style.height = `${leftMag / MAX_VALUE_ENCODER_DELTA * 100}%`;
-    dom.encoderRightBar.style.height = `${rightMag / MAX_VALUE_ENCODER_DELTA * 100}%`;
-
-    const leftDir = Math.sign(leftDelta);
-    const rightDir = Math.sign(rightDelta);
-    dom.encoderLeftBar.classList.toggle('bg-orange-500', leftDir < 0);
-    dom.encoderLeftBar.classList.toggle('bg-purple-500', leftDir >= 0);
-    dom.encoderRightBar.classList.toggle('bg-orange-500', rightDir < 0);
-    dom.encoderRightBar.classList.toggle('bg-purple-500', rightDir >= 0);
+    dom.leftEncoder.textContent = `Left Encoder: ${data.leftEncoder}`;
+    dom.rightEncoder.textContent = `Right Encoder: ${data.rightEncoder}`;
 
 
     if(oiMode === 'Full') {

--- a/roombaStatus.js
+++ b/roombaStatus.js
@@ -3,7 +3,7 @@ const roombaStatus = {
     docked: null,
     chargeStatus: null,
     batteryVoltage: 16000,
-    batteryPercentage: 3000,
+    batteryPercentage: 0,
     bumpSensors: {
         bumpLeft: 'OFF',
         bumpRight: 'OFF'
@@ -15,6 +15,10 @@ const roombaStatus = {
         LBCR: 36,
         LBFR: 30,
         LBR: 33
+    },
+    wheelEncoders: {
+        left: 0,
+        right: 0
     }
 };
 


### PR DESCRIPTION
## Summary
- wire up Open Interface packets for left/right encoder counts and motor currents
- show signed wheel motion with color-coded bars on the UI
- initialize battery percentage sanely on startup

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bba506afc88327b0d3ed76c5bfcf8e