### PR TITLE
Add autonomous behavior stack with planner and world model

### DIFF
--- a/autonomy/behaviors/BehaviorManager.js
+++ b/autonomy/behaviors/BehaviorManager.js
@@ -1,0 +1,474 @@
+const EventEmitter = require('events');
+
+const DEFAULT_WANDER_SPEED = 160;
+const DEFAULT_ROTATE_SPEED = 120;
+const WALL_TARGET_INTENSITY = 250;
+
+class BehaviorManager extends EventEmitter {
+  constructor(controller, worldModel, options = {}) {
+    super();
+    this.controller = controller;
+    this.worldModel = worldModel;
+
+    this.enabled = false;
+    this.currentBehavior = 'idle';
+    this.currentParams = {};
+    this.currentMeta = {};
+    this.behaviorState = null;
+    this.behaviorStack = [];
+    this.manualOverrideActive = false;
+    this.latestSensors = null;
+    this.defaultBehavior = options.defaultBehavior || 'wander';
+    this.recentReflexes = [];
+    this.lastBumpTrigger = 0;
+    this.lastCycleAt = null;
+    this.lastManualCommand = null;
+
+    if (this.controller) {
+      this.controller.on('roomba:done', (movement) => this._onMovementComplete(movement));
+      this.controller.on('roomba:queue-empty', () => this._onQueueEmpty());
+    }
+  }
+
+  enableAutonomy(reason = 'enabled') {
+    if (this.enabled) {
+      return;
+    }
+    this.enabled = true;
+    this.behaviorState = null;
+    if (this.currentBehavior === 'idle') {
+      this.setBehavior(this.defaultBehavior, { reason: 'auto-start' }, { source: 'autonomy', forceImmediate: true });
+    }
+    this.emit('state', this.getStatusSnapshot({ reason }));
+  }
+
+  disableAutonomy(reason = 'disabled') {
+    if (!this.enabled) {
+      return;
+    }
+    this.enabled = false;
+    this.behaviorStack = [];
+    this.manualOverrideActive = false;
+    this.halt(reason);
+    this.currentBehavior = 'idle';
+    this.currentParams = {};
+    this.currentMeta = { reason, source: 'autonomy' };
+    this.emit('state', this.getStatusSnapshot({ reason }));
+  }
+
+  halt(reason = 'halted') {
+    if (this.controller) {
+      this.controller.stop();
+      this.controller.clearQueue();
+    }
+    this.behaviorState = null;
+    this.emit('state', this.getStatusSnapshot({ reason, halted: true }));
+  }
+
+  setDefaultBehavior(name, params = {}) {
+    this.defaultBehavior = name || 'wander';
+    if (Object.keys(params).length) {
+      this.defaultBehaviorParams = params;
+    }
+    this.emit('state', this.getStatusSnapshot({ reason: 'default-updated' }));
+  }
+
+  setBehavior(name, params = {}, meta = {}) {
+    const normalizedName = name || 'idle';
+    const previous = {
+      name: this.currentBehavior,
+      params: this.currentParams,
+      meta: this.currentMeta,
+    };
+
+    if (meta.stack && previous.name && previous.name !== 'idle') {
+      this.behaviorStack.push({ name: previous.name, params: previous.params, meta: previous.meta });
+    }
+
+    this.currentBehavior = normalizedName;
+    this.currentParams = params || {};
+    this.currentMeta = {
+      ...meta,
+      source: meta.source || 'planner',
+      startedAt: Date.now(),
+    };
+    this.behaviorState = {
+      startedAt: Date.now(),
+      meta: this.currentMeta,
+      name: this.currentBehavior,
+      params: this.currentParams,
+    };
+
+    if (normalizedName === 'idle') {
+      this.halt(meta.reason || 'idle');
+    } else if (!meta.skipDrive) {
+      this._executeBehavior(normalizedName, meta);
+    }
+
+    this.emit('state', this.getStatusSnapshot({ reason: meta.reason || 'behavior-change' }));
+  }
+
+  restorePreviousBehavior(reason = 'resume') {
+    const resume = this.behaviorStack.pop();
+    if (resume) {
+      this.setBehavior(resume.name, resume.params, {
+        ...resume.meta,
+        source: 'behavior-manager',
+        reason,
+        skipDrive: false,
+      });
+    } else if (this.enabled) {
+      this.setBehavior(this.defaultBehavior, this.defaultBehaviorParams || {}, {
+        source: 'behavior-manager',
+        reason: `${reason} (fallback)`
+      });
+    } else {
+      this.setBehavior('idle', {}, { source: 'behavior-manager', reason: `${reason} (disabled)` });
+    }
+  }
+
+  enqueueManualMotion(action, rawValue) {
+    const value = Number.parseFloat(rawValue);
+    if (!Number.isFinite(value)) {
+      return;
+    }
+
+    let distance = 0;
+    let turn = 0;
+    switch (action) {
+      case 'forward':
+        distance = Math.max(20, Math.min(600, value));
+        break;
+      case 'backward':
+        distance = -Math.max(20, Math.min(600, Math.abs(value)));
+        break;
+      case 'left':
+        turn = Math.max(5, Math.min(180, value));
+        break;
+      case 'right':
+        turn = -Math.max(5, Math.min(180, value));
+        break;
+      default:
+        return;
+    }
+
+    if (this.controller) {
+      this.controller.stop();
+      this.controller.clearQueue();
+      this.manualOverrideActive = true;
+      this.lastManualCommand = {
+        issuedAt: Date.now(),
+        action,
+        value,
+      };
+      this.controller.move(distance, turn, DEFAULT_WANDER_SPEED);
+      this.emit('manual-override', {
+        action,
+        value,
+        timestamp: Date.now(),
+      });
+    }
+    this.emit('state', this.getStatusSnapshot({ reason: 'manual-override' }));
+  }
+
+  updateSensors(sensorData = {}) {
+    this.latestSensors = sensorData;
+    if (this.worldModel) {
+      this.worldModel.updateFromSensors({
+        ...sensorData,
+        batteryPercentage: sensorData.batteryPercentage,
+      });
+    }
+
+    const now = Date.now();
+    const bump = Boolean(sensorData.bumpLeft || sensorData.bumpRight);
+    const cliff = Array.isArray(sensorData.cliffSensors) && sensorData.cliffSensors.some(value => value < 100);
+
+    if (this.enabled && !this.manualOverrideActive) {
+      if (bump && now - this.lastBumpTrigger > 600) {
+        const direction = sensorData.bumpLeft ? 'left' : sensorData.bumpRight ? 'right' : 'unknown';
+        this.lastBumpTrigger = now;
+        this.recentReflexes.push({
+          type: 'bump',
+          direction,
+          at: now,
+        });
+        if (this.recentReflexes.length > 8) {
+          this.recentReflexes.shift();
+        }
+        this.emit('reflex', { type: 'bump', direction, at: now });
+        this.setBehavior('avoid', { direction }, {
+          source: 'reflex',
+          reason: 'bump-detected',
+          stack: true,
+        });
+        return;
+      }
+
+      if (cliff && this.currentBehavior !== 'avoid') {
+        this.recentReflexes.push({ type: 'cliff', at: now });
+        this.emit('reflex', { type: 'cliff', at: now });
+        this.setBehavior('avoid', { direction: 'right', retreat: true }, {
+          source: 'reflex',
+          reason: 'cliff-detected',
+          stack: true,
+        });
+        return;
+      }
+    }
+  }
+
+  describeStatus() {
+    const snapshot = this.getStatusSnapshot();
+    const pieces = [
+      `enabled=${snapshot.enabled}`,
+      `behavior=${snapshot.behavior}`,
+    ];
+    if (snapshot.behavior === 'wall_follow' && snapshot.params?.side) {
+      pieces.push(`side=${snapshot.params.side}`);
+    }
+    if (snapshot.manualOverride) {
+      pieces.push('manual=active');
+    }
+    if (this.recentReflexes.length) {
+      const last = this.recentReflexes[this.recentReflexes.length - 1];
+      pieces.push(`last_reflex=${last.type}`);
+    }
+    return pieces.join(', ');
+  }
+
+  getStatusSnapshot(extras = {}) {
+    return {
+      enabled: this.enabled,
+      behavior: this.currentBehavior,
+      params: this.currentParams,
+      meta: this.currentMeta,
+      manualOverride: this.manualOverrideActive,
+      lastManualCommand: this.lastManualCommand,
+      lastCycleAt: this.lastCycleAt,
+      stackDepth: this.behaviorStack.length,
+      recentReflexes: this.recentReflexes.slice(-5),
+      latestSensors: this._condenseSensors(this.latestSensors),
+      ...extras,
+    };
+  }
+
+  _condenseSensors(sensorData) {
+    if (!sensorData) {
+      return null;
+    }
+    return {
+      bumpLeft: sensorData.bumpLeft,
+      bumpRight: sensorData.bumpRight,
+      lightBumps: sensorData.lightBumps,
+      dirtDetect: sensorData.dirtDetect,
+    };
+  }
+
+  _executeBehavior(name, meta = {}) {
+    if (!this.enabled && name !== 'idle' && !meta.allowWhileDisabled) {
+      return;
+    }
+
+    switch (name) {
+      case 'idle':
+        this.halt(meta.reason || 'idle');
+        break;
+      case 'wander':
+        this._queueWanderMove(true);
+        break;
+      case 'wall_follow':
+        this._queueWallFollowMove(true);
+        break;
+      case 'scan':
+        this._queueScanStep(true);
+        break;
+      case 'dock_seek':
+        this._queueDockSeekStep(true);
+        break;
+      case 'avoid':
+        this._queueAvoidSequence(meta);
+        break;
+      default:
+        this.emit('log', `Unknown behavior '${name}'`);
+    }
+  }
+
+  _queueWanderMove(forceTurn = false) {
+    if (!this.controller || !this.enabled || this.manualOverrideActive) {
+      return;
+    }
+    const distance = 180 + Math.random() * 160;
+    let turn = 0;
+    if (forceTurn || Math.random() < 0.35) {
+      turn = (Math.random() - 0.5) * 120;
+    }
+    if (this.behaviorState) {
+      this.behaviorState.lastPlannedMove = { distance, turn };
+    }
+    this.controller.move(distance, turn, DEFAULT_WANDER_SPEED);
+  }
+
+  _queueWallFollowMove(force = false) {
+    if (!this.controller || !this.enabled || this.manualOverrideActive) {
+      return;
+    }
+    const side = this.currentParams.side === 'right' ? 'right' : 'left';
+    const light = this.latestSensors?.lightBumps || {};
+
+    const leftValue = (light.centerLeft || 0) + (light.frontLeft || 0);
+    const rightValue = (light.centerRight || 0) + (light.frontRight || 0);
+    const target = WALL_TARGET_INTENSITY;
+
+    let error;
+    if (side === 'left') {
+      error = target - leftValue;
+    } else {
+      error = target - rightValue;
+    }
+
+    let turnAdjust = error * 0.05;
+    turnAdjust = Math.max(-25, Math.min(25, turnAdjust));
+
+    if (Math.abs(leftValue - rightValue) < 40 && !force) {
+      turnAdjust += side === 'left' ? 10 : -10;
+    }
+
+    const distance = 160;
+    this.controller.move(distance, turnAdjust, DEFAULT_WANDER_SPEED);
+    if (this.behaviorState) {
+      this.behaviorState.lastPlannedMove = { distance, turn: turnAdjust };
+    }
+  }
+
+  _queueScanStep(force = false) {
+    if (!this.controller || !this.enabled || this.manualOverrideActive) {
+      return;
+    }
+    const turn = this.currentParams.turnSize || 60;
+    const cycles = this.currentParams.cycles || 6;
+    const state = this.behaviorState || {};
+    const completed = state.completedTurns || 0;
+
+    if (!force && completed >= cycles) {
+      this.restorePreviousBehavior('scan-finished');
+      return;
+    }
+
+    this.controller.move(0, turn, DEFAULT_ROTATE_SPEED);
+    this.behaviorState = {
+      ...state,
+      completedTurns: completed + 1,
+      lastPlannedMove: { distance: 0, turn },
+      awaitingResume: completed + 1 >= cycles,
+      sequence: 'scan',
+    };
+  }
+
+  _queueDockSeekStep(force = false) {
+    if (!this.controller || !this.enabled || this.manualOverrideActive) {
+      return;
+    }
+    const state = this.behaviorState || {};
+    const phase = state.phase || 0;
+    if (force) {
+      this.behaviorState = { ...state, phase: 0 };
+    }
+    if (phase % 2 === 0) {
+      this.controller.move(-120, 0, DEFAULT_WANDER_SPEED);
+    } else {
+      this.controller.move(0, 45, DEFAULT_ROTATE_SPEED);
+    }
+    this.behaviorState = {
+      ...this.behaviorState,
+      phase: (phase + 1) % 6,
+      lastPlannedMove: { distance: phase % 2 === 0 ? -120 : 0, turn: phase % 2 === 0 ? 0 : 45 },
+    };
+  }
+
+  _queueAvoidSequence(meta = {}) {
+    if (!this.controller) {
+      return;
+    }
+    this.controller.stop();
+    this.controller.clearQueue();
+
+    const direction = meta.direction === 'left' || this.currentParams.direction === 'left' ? 'left' : 'right';
+    const turn = direction === 'left' ? -60 : 60;
+    const retreatDistance = meta.retreat ? -200 : -150;
+
+    this.controller.move(retreatDistance, 0, DEFAULT_WANDER_SPEED);
+    this.controller.move(0, turn, DEFAULT_ROTATE_SPEED);
+    this.controller.move(150, 0, DEFAULT_WANDER_SPEED);
+
+    this.behaviorState = {
+      ...this.behaviorState,
+      sequence: 'avoid',
+      awaitingResume: true,
+      resumeReason: meta.reason || 'avoid-finished',
+      lastPlannedMove: { distance: 150, turn: 0 },
+    };
+  }
+
+  _onMovementComplete(movement) {
+    this.lastCycleAt = Date.now();
+    if (this.worldModel) {
+      this.worldModel.recordMovement(movement.distanceMm, movement.turnDeg);
+    }
+    this.emit('cycle-complete', {
+      behavior: this.currentBehavior,
+      timestamp: this.lastCycleAt,
+      movement,
+    });
+  }
+
+  _onQueueEmpty() {
+    if (this.manualOverrideActive) {
+      this.manualOverrideActive = false;
+      if (this.enabled && this.currentBehavior !== 'idle') {
+        this._driveBehavior(false);
+      }
+      this.emit('state', this.getStatusSnapshot({ reason: 'manual-complete' }));
+      return;
+    }
+
+    if (this.behaviorState && this.behaviorState.awaitingResume) {
+      const reason = this.behaviorState.resumeReason || 'sequence-complete';
+      this.behaviorState.awaitingResume = false;
+      this.restorePreviousBehavior(reason);
+      return;
+    }
+
+    if (!this.enabled) {
+      return;
+    }
+
+    this._driveBehavior(false);
+  }
+
+  _driveBehavior(force) {
+    switch (this.currentBehavior) {
+      case 'wander':
+        this._queueWanderMove(force);
+        break;
+      case 'wall_follow':
+        this._queueWallFollowMove(force);
+        break;
+      case 'scan':
+        this._queueScanStep(force);
+        break;
+      case 'dock_seek':
+        this._queueDockSeekStep(force);
+        break;
+      case 'avoid':
+        // avoid is scheduled immediately when set
+        break;
+      default:
+        break;
+    }
+  }
+}
+
+module.exports = {
+  BehaviorManager,
+};

--- a/autonomy/perception/WorldModel.js
+++ b/autonomy/perception/WorldModel.js
@@ -1,0 +1,285 @@
+const EventEmitter = require('events');
+
+const RELATIVE_LIGHT_ANGLES = {
+  left: 135,
+  frontLeft: 60,
+  centerLeft: 25,
+  centerRight: -25,
+  frontRight: -60,
+  right: -135,
+};
+
+const RELATIVE_DESCRIPTOR_BREAKS = [
+  { max: 22.5, label: 'front' },
+  { max: 67.5, label: 'front-right' },
+  { max: 112.5, label: 'right' },
+  { max: 157.5, label: 'rear-right' },
+  { max: 180, label: 'rear' },
+];
+
+function normalizeAngle(deg) {
+  const wrapped = deg % 360;
+  return wrapped < -180 ? wrapped + 360 : wrapped > 180 ? wrapped - 360 : wrapped;
+}
+
+class WorldModel extends EventEmitter {
+  constructor(options = {}) {
+    super();
+    this.sectorCount = options.sectorCount || 12;
+    this.ringCount = options.ringCount || 3;
+    this.breadcrumbLimit = options.breadcrumbLimit || 60;
+    this.summaryIntervalMs = options.summaryIntervalMs || 1500;
+
+    this.sectors = Array.from({ length: this.sectorCount }, () => this._createSector());
+    this.headingDeg = 0;
+    this.position = { x: 0, y: 0 };
+    this.breadcrumbs = [];
+    this.interestingSightings = [];
+    this.lastSummaryBroadcast = 0;
+    this.lastSensorSnapshot = null;
+    this.lastBatteryPercentage = null;
+    this.lastMovementAt = Date.now();
+    this.lastUpdate = Date.now();
+    this.autoStuckCounter = 0;
+  }
+
+  _createSector() {
+    return {
+      obstacles: 0,
+      lightScore: 0,
+      forbiddenScore: 0,
+      lastUpdated: 0,
+      recentNotes: [],
+    };
+  }
+
+  _sectorWidthDeg() {
+    return 360 / this.sectorCount;
+  }
+
+  _sectorAngle(index) {
+    const width = this._sectorWidthDeg();
+    return index * width + width / 2;
+  }
+
+  _angleToSector(angleDeg) {
+    const normalized = ((angleDeg % 360) + 360) % 360;
+    const width = this._sectorWidthDeg();
+    return Math.floor(normalized / width) % this.sectorCount;
+  }
+
+  _relativeDescriptor(angleDeg) {
+    const relative = Math.abs(normalizeAngle(angleDeg - this.headingDeg));
+    for (const bucket of RELATIVE_DESCRIPTOR_BREAKS) {
+      if (relative <= bucket.max) {
+        return bucket.label;
+      }
+    }
+    // Mirror for left-hand side descriptors
+    if (relative >= 180 - RELATIVE_DESCRIPTOR_BREAKS[1].max) {
+      return 'rear-left';
+    }
+    if (relative >= 180 - RELATIVE_DESCRIPTOR_BREAKS[2].max) {
+      return 'left';
+    }
+    if (relative >= 180 - RELATIVE_DESCRIPTOR_BREAKS[3].max) {
+      return 'front-left';
+    }
+    return 'front-left';
+  }
+
+  recordMovement(distanceMm, turnDeg) {
+    if (!Number.isFinite(distanceMm) || !Number.isFinite(turnDeg)) {
+      return;
+    }
+
+    const midHeading = this.headingDeg + turnDeg / 2;
+    const rad = (midHeading * Math.PI) / 180;
+
+    this.position.x += Math.cos(rad) * distanceMm;
+    this.position.y += Math.sin(rad) * distanceMm;
+
+    this.headingDeg = normalizeAngle(this.headingDeg + turnDeg);
+    this.lastMovementAt = Date.now();
+
+    if (Math.hypot(distanceMm, turnDeg) > 20) {
+      this._addBreadcrumb({
+        x: this.position.x,
+        y: this.position.y,
+        heading: this.headingDeg,
+        timestamp: Date.now(),
+      });
+    }
+
+    this._emitSummaryMaybe(false);
+  }
+
+  _addBreadcrumb(breadcrumb) {
+    this.breadcrumbs.push(breadcrumb);
+    if (this.breadcrumbs.length > this.breadcrumbLimit) {
+      this.breadcrumbs.shift();
+    }
+  }
+
+  updateFromSensors(sensorData = {}) {
+    this.lastSensorSnapshot = sensorData;
+    this.lastUpdate = Date.now();
+
+    if (typeof sensorData.batteryPercentage === 'number') {
+      this.lastBatteryPercentage = sensorData.batteryPercentage;
+    }
+
+    if (sensorData.bumpLeft || sensorData.bumpRight) {
+      const relativeAngle = sensorData.bumpLeft ? 30 : -30;
+      this._markObstacle(relativeAngle, 'contact');
+    }
+
+    if (Array.isArray(sensorData.cliffSensors)) {
+      const dangerous = sensorData.cliffSensors.some(value => value < 100);
+      if (dangerous) {
+        this._markObstacle(0, 'cliff');
+      }
+    }
+
+    if (sensorData.lightBumps) {
+      this._processLightBumps(sensorData.lightBumps);
+    }
+
+    if (sensorData.dirtDetect && sensorData.dirtDetect > 0) {
+      this._logSighting(`dirt sensor spike (${sensorData.dirtDetect})`, 'maintenance');
+    }
+
+    this._emitSummaryMaybe(false);
+  }
+
+  _processLightBumps(lightBumps) {
+    const entries = Object.entries(lightBumps);
+    if (!entries.length) {
+      return;
+    }
+
+    let peak = { key: null, value: -Infinity };
+    for (const [key, value] of entries) {
+      const numeric = Number(value) || 0;
+      if (numeric > peak.value) {
+        peak = { key, value: numeric };
+      }
+    }
+
+    const threshold = 120;
+    for (const [key, value] of entries) {
+      const numeric = Number(value) || 0;
+      const relAngle = RELATIVE_LIGHT_ANGLES[key] ?? 0;
+      const descriptor = numeric > threshold ? 'proximity' : 'ambient';
+      if (descriptor === 'proximity') {
+        this._markObstacle(relAngle, `light-${key}`);
+      }
+      this._accumulateLight(relAngle, numeric);
+    }
+
+    if (peak.key && peak.value > threshold * 2) {
+      this._logSighting(`bright return ${peak.key} (${Math.round(peak.value)})`, 'vision');
+    }
+  }
+
+  _markObstacle(relativeAngle, note) {
+    const absoluteAngle = normalizeAngle(this.headingDeg + relativeAngle);
+    const sector = this._angleToSector(absoluteAngle);
+    const sectorData = this.sectors[sector];
+    sectorData.obstacles += 1;
+    sectorData.forbiddenScore = Math.min(sectorData.forbiddenScore + 1, 10);
+    sectorData.lastUpdated = Date.now();
+    if (note) {
+      sectorData.recentNotes.push({ note, at: Date.now() });
+      if (sectorData.recentNotes.length > 5) {
+        sectorData.recentNotes.shift();
+      }
+    }
+    this._emitSummaryMaybe(false);
+  }
+
+  _accumulateLight(relativeAngle, value) {
+    const absoluteAngle = normalizeAngle(this.headingDeg + relativeAngle);
+    const sector = this._angleToSector(absoluteAngle);
+    const sectorData = this.sectors[sector];
+    sectorData.lightScore = Math.round((sectorData.lightScore * 0.7) + value * 0.3);
+    sectorData.lastUpdated = Date.now();
+  }
+
+  _logSighting(description, category = 'generic') {
+    this.interestingSightings.push({
+      description,
+      category,
+      at: Date.now(),
+    });
+    if (this.interestingSightings.length > 30) {
+      this.interestingSightings.shift();
+    }
+  }
+
+  describeForLLM() {
+    const posX = Math.round(this.position.x);
+    const posY = Math.round(this.position.y);
+    const heading = Math.round(((this.headingDeg % 360) + 360) % 360);
+
+    const obstacleSummary = this._buildObstacleSummary();
+    const interesting = this.interestingSightings.slice(-3).map(entry => entry.description);
+    const battery = this.lastBatteryPercentage != null ? `${this.lastBatteryPercentage}%` : 'unknown';
+    const timeSinceMovement = Math.round((Date.now() - this.lastMovementAt) / 1000);
+
+    return `pose_mm: (${posX}, ${posY}), heading: ${heading}deg. battery: ${battery}. ` +
+      `recent_obstacles: ${obstacleSummary || 'none observed'}. ` +
+      `recent_sightings: ${interesting.join('; ') || 'none'}. ` +
+      `stopped_for: ${timeSinceMovement}s.`;
+  }
+
+  _buildObstacleSummary() {
+    const descriptorCounts = {};
+    this.sectors.forEach((sectorData, index) => {
+      if (sectorData.obstacles <= 0 && sectorData.forbiddenScore <= 0) {
+        return;
+      }
+      const label = this._relativeDescriptor(this._sectorAngle(index));
+      descriptorCounts[label] = (descriptorCounts[label] || 0) + sectorData.obstacles;
+    });
+
+    return Object.entries(descriptorCounts)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 4)
+      .map(([label, count]) => `${label} x${count}`)
+      .join(', ');
+  }
+
+  getBreadcrumbs() {
+    return this.breadcrumbs.slice();
+  }
+
+  getLastSummaryPayload() {
+    return {
+      summary: this.describeForLLM(),
+      heading: this.headingDeg,
+      position: { ...this.position },
+      breadcrumbs: this.getBreadcrumbs(),
+      lastSensorSnapshot: this.lastSensorSnapshot,
+      batteryPercentage: this.lastBatteryPercentage,
+      updatedAt: this.lastUpdate,
+    };
+  }
+
+  forceEmitSummary() {
+    this._emitSummaryMaybe(true);
+  }
+
+  _emitSummaryMaybe(force) {
+    const now = Date.now();
+    if (!force && now - this.lastSummaryBroadcast < this.summaryIntervalMs) {
+      return;
+    }
+    this.lastSummaryBroadcast = now;
+    this.emit('summary', this.getLastSummaryPayload());
+  }
+}
+
+module.exports = {
+  WorldModel,
+};

--- a/autonomy/planner/MissionPlanner.js
+++ b/autonomy/planner/MissionPlanner.js
@@ -1,0 +1,374 @@
+const EventEmitter = require('events');
+
+let nextStepId = 1;
+
+class MissionPlanner extends EventEmitter {
+  constructor(behaviorManager, worldModel, options = {}) {
+    super();
+    this.behaviorManager = behaviorManager;
+    this.worldModel = worldModel;
+
+    this.queue = [];
+    this.activeStep = null;
+    this.history = [];
+    this.goalHistory = [];
+    this.currentGoalText = null;
+    this.running = false;
+
+    this.autoExplore = options.autoExplore !== false;
+    this.autoExploreCooldownMs = options.autoExploreCooldownMs || 20000;
+    this.nextAutoExploreAt = Date.now();
+    this.defaultAutoStep = options.defaultAutoStep || 'wander';
+
+    if (this.behaviorManager) {
+      this.behaviorManager.on('cycle-complete', () => this.tick());
+      this.behaviorManager.on('reflex', (event) => this._handleReflex(event));
+      this.behaviorManager.on('state', (state) => this._handleBehaviorState(state));
+    }
+  }
+
+  start() {
+    if (this.running) {
+      return;
+    }
+    this.running = true;
+    this.tick();
+  }
+
+  stop() {
+    if (!this.running) {
+      return;
+    }
+    this.running = false;
+    this.activeStep = null;
+    this.queue = [];
+    this.emit('mission-updated', this.getStatusSnapshot({ reason: 'planner-stopped' }));
+  }
+
+  clearQueue(reason = 'cleared') {
+    this.queue = [];
+    this.emit('mission-updated', this.getStatusSnapshot({ reason }));
+  }
+
+  ingestLLMGoal(goalText, options = {}) {
+    if (!goalText || typeof goalText !== 'string') {
+      return;
+    }
+    const trimmed = goalText.trim();
+    if (!trimmed) {
+      return;
+    }
+
+    const source = options.source || 'llm';
+    this.currentGoalText = trimmed;
+    this.goalHistory.push({ text: trimmed, at: Date.now(), source });
+    if (this.goalHistory.length > 20) {
+      this.goalHistory.shift();
+    }
+
+    const steps = this._parseGoalToSteps(trimmed);
+
+    if (!options.append) {
+      this.queue = [];
+      if (this.activeStep) {
+        this._completeStep('replaced');
+      }
+      if (this.behaviorManager) {
+        this.behaviorManager.halt('new-goal');
+      }
+      this.activeStep = null;
+    }
+
+    this.queue.push(...steps);
+    this.emit('mission-updated', this.getStatusSnapshot({ reason: 'new-goal', source }));
+    this.tick();
+  }
+
+  ingestDirective(text, options = {}) {
+    if (!text || typeof text !== 'string') {
+      return;
+    }
+    const directive = text.trim();
+    if (!directive) {
+      return;
+    }
+
+    const lower = directive.toLowerCase();
+    if (lower.startsWith('clear')) {
+      this.clearQueue('directive-clear');
+      return;
+    }
+    if (lower.startsWith('pause') || lower.startsWith('hold')) {
+      this.queue.unshift(this._createStep('idle', {
+        durationMs: this._extractDuration(lower) || 5000,
+        note: 'pause directive',
+        source: 'directive',
+      }));
+      this.emit('mission-updated', this.getStatusSnapshot({ reason: 'directive-pause' }));
+      this.tick();
+      return;
+    }
+
+    const steps = this._parseGoalToSteps(directive);
+    if (options.prepend || lower.startsWith('now')) {
+      this.queue = steps.concat(this.queue);
+    } else {
+      this.queue.push(...steps);
+    }
+    this.emit('mission-updated', this.getStatusSnapshot({ reason: 'directive', directive }));
+    this.tick();
+  }
+
+  tick() {
+    if (!this.running) {
+      return;
+    }
+    const now = Date.now();
+
+    if (this.activeStep && this.activeStep.deadline && now >= this.activeStep.deadline) {
+      this._completeStep('deadline');
+    }
+
+    if (!this.activeStep) {
+      if (this.queue.length === 0 && this.autoExplore && now >= this.nextAutoExploreAt) {
+        this.queue.push(this._createStep(this.defaultAutoStep, {
+          durationMs: 15000,
+          note: 'auto-explore pulse',
+          source: 'auto',
+          auto: true,
+        }));
+        this.nextAutoExploreAt = now + this.autoExploreCooldownMs;
+      }
+
+      if (this.queue.length > 0) {
+        const nextStep = this.queue.shift();
+        this._startStep(nextStep);
+      } else if (this.behaviorManager && this.autoExplore) {
+        this.behaviorManager.setBehavior(this.defaultAutoStep, {}, {
+          source: 'auto',
+          reason: 'idle-auto',
+        });
+      }
+    }
+  }
+
+  describeStatus() {
+    const active = this.activeStep ? `${this.activeStep.behavior}${this.activeStep.deadline ? ` (until ${Math.round((this.activeStep.deadline - Date.now()) / 1000)}s)` : ''}` : 'idle';
+    const queuePreview = this.queue.map((step) => step.behavior).slice(0, 3).join(' -> ') || 'empty';
+    const goal = this.currentGoalText || 'none';
+    return `goal: ${goal}. active_step: ${active}. queue: ${queuePreview}. auto_explore: ${this.autoExplore}`;
+  }
+
+  markStepComplete(reason = 'completed') {
+    this._completeStep(reason);
+    this.tick();
+  }
+
+  failActiveStep(reason = 'failed') {
+    this._completeStep(`failed:${reason}`);
+    this.tick();
+  }
+
+  getStatusSnapshot(extras = {}) {
+    return {
+      running: this.running,
+      currentGoal: this.currentGoalText,
+      activeStep: this._summarizeStep(this.activeStep),
+      queue: this.queue.map((step) => this._summarizeStep(step)),
+      history: this.history.slice(-8).map((step) => this._summarizeStep(step)),
+      autoExplore: this.autoExplore,
+      nextAutoExploreAt: this.nextAutoExploreAt,
+      goalHistory: this.goalHistory.slice(-8),
+      ...extras,
+    };
+  }
+
+  _startStep(step) {
+    if (!step) {
+      return;
+    }
+    const prepared = {
+      ...step,
+      status: 'active',
+      startedAt: Date.now(),
+    };
+    if (step.durationMs) {
+      prepared.deadline = Date.now() + step.durationMs;
+    }
+    this.activeStep = prepared;
+    if (this.behaviorManager) {
+      this.behaviorManager.setBehavior(step.behavior, step.params || {}, {
+        source: 'mission-planner',
+        reason: step.note || step.source || 'mission-step',
+      });
+    }
+    this.emit('mission-updated', this.getStatusSnapshot({ reason: 'step-started', stepId: step.id }));
+  }
+
+  _completeStep(result = 'completed') {
+    if (this.activeStep) {
+      const finished = {
+        ...this.activeStep,
+        status: result.startsWith('failed') ? 'failed' : 'completed',
+        completedAt: Date.now(),
+        result,
+      };
+      this.history.push(finished);
+      if (this.history.length > 20) {
+        this.history.shift();
+      }
+    }
+    this.activeStep = null;
+    if (this.behaviorManager && !this.queue.length) {
+      this.behaviorManager.setBehavior(this.defaultAutoStep, {}, {
+        source: 'mission-planner',
+        reason: 'step-finished',
+      });
+    }
+    this.emit('mission-updated', this.getStatusSnapshot({ reason: `step-${result}` }));
+  }
+
+  _handleReflex(event) {
+    if (!this.running || !this.activeStep) {
+      return;
+    }
+    this.activeStep.lastReflex = event;
+    this.emit('mission-updated', this.getStatusSnapshot({ reason: 'reflex', event }));
+  }
+
+  _handleBehaviorState(state) {
+    if (!this.running || !this.activeStep) {
+      return;
+    }
+    if (state && state.reason && state.reason.includes('scan-finished') && this.activeStep.behavior === 'scan') {
+      this.markStepComplete('behavior-finished');
+    }
+  }
+
+  _parseGoalToSteps(goalText) {
+    const lower = goalText.toLowerCase();
+    const steps = [];
+    const durationMs = this._extractDuration(goalText) || 15000;
+
+    if (lower.includes('dock') || lower.includes('charge') || lower.includes('base')) {
+      steps.push(this._createStep('dock_seek', {
+        durationMs: Math.max(durationMs, 20000),
+        note: 'search for dock',
+        source: 'goal',
+      }));
+      return steps;
+    }
+
+    if (lower.includes('wall')) {
+      const side = lower.includes('right') ? 'right' : 'left';
+      steps.push(this._createStep('wall_follow', {
+        params: { side },
+        durationMs,
+        note: `follow ${side} wall`,
+        source: 'goal',
+      }));
+      return steps;
+    }
+
+    if (lower.includes('scan') || lower.includes('inspect') || lower.includes('look around')) {
+      steps.push(this._createStep('scan', {
+        params: { turnSize: 60, cycles: 6 },
+        durationMs: Math.max(durationMs, 8000),
+        note: 'slow scan',
+        source: 'goal',
+      }));
+      if (lower.includes('explore') || lower.includes('then') || !lower.includes('stop')) {
+        steps.push(this._createStep('wander', {
+          durationMs,
+          note: 'resume exploring',
+          source: 'goal',
+        }));
+      }
+      return steps;
+    }
+
+    if (lower.includes('patrol') || lower.includes('explore') || lower.includes('wander')) {
+      steps.push(this._createStep('wander', {
+        durationMs,
+        note: 'explore area',
+        source: 'goal',
+      }));
+      return steps;
+    }
+
+    if (lower.includes('idle') || lower.includes('wait') || lower.includes('hold position')) {
+      steps.push(this._createStep('idle', {
+        durationMs: Math.max(durationMs, 5000),
+        note: 'hold still',
+        source: 'goal',
+      }));
+      return steps;
+    }
+
+    if (lower.includes('follow') && lower.includes('light')) {
+      steps.push(this._createStep('wander', {
+        durationMs,
+        note: 'approach bright area',
+        source: 'goal',
+      }));
+      return steps;
+    }
+
+    steps.push(this._createStep('wander', {
+      durationMs,
+      note: 'default explore',
+      source: 'goal',
+    }));
+    return steps;
+  }
+
+  _extractDuration(text) {
+    const seconds = text.match(/(\d+)\s*(seconds|second|sec|s)/i);
+    if (seconds) {
+      return Number.parseInt(seconds[1], 10) * 1000;
+    }
+    const minutes = text.match(/(\d+)\s*(minutes|minute|min)/i);
+    if (minutes) {
+      return Number.parseInt(minutes[1], 10) * 60000;
+    }
+    return null;
+  }
+
+  _createStep(behavior, { params = {}, durationMs = 10000, note = '', source = 'planner', auto = false } = {}) {
+    return {
+      id: nextStepId++,
+      behavior,
+      params,
+      durationMs,
+      note,
+      source,
+      status: 'queued',
+      createdAt: Date.now(),
+      auto,
+    };
+  }
+
+  _summarizeStep(step) {
+    if (!step) {
+      return null;
+    }
+    return {
+      id: step.id,
+      behavior: step.behavior,
+      params: step.params,
+      durationMs: step.durationMs,
+      note: step.note,
+      source: step.source,
+      status: step.status,
+      startedAt: step.startedAt,
+      completedAt: step.completedAt,
+      deadline: step.deadline,
+      result: step.result,
+      auto: step.auto,
+    };
+  }
+}
+
+module.exports = {
+  MissionPlanner,
+};

--- a/autonomy/planner/MissionPlanner.js
+++ b/autonomy/planner/MissionPlanner.js
@@ -150,6 +150,10 @@ class MissionPlanner extends EventEmitter {
         });
       }
     }
+
+    if (this.behaviorManager && typeof this.behaviorManager.ensureBehaviorActive === 'function') {
+      this.behaviorManager.ensureBehaviorActive();
+    }
   }
 
   describeStatus() {

--- a/prompts/system.txt
+++ b/prompts/system.txt
@@ -1,0 +1,25 @@
+# Mission Director System Prompt
+
+You are the mission director for the Roomba Rover. A deterministic autonomy stack on the robot handles navigation, reflexes, and low-level motion. Your job is to read the world/mission/behavior summaries, narrate your intent, and issue strategic directives that keep the robot exploring safely and purposefully.
+
+## How to Think
+- Treat the robot like a teammate: acknowledge what it just did, note anything interesting in the world summary, and decide the next purposeful mission.
+- Assume behaviors such as `wander`, `wall_follow`, `scan`, and `dock_seek` already know how to drive. You simply choose when and why to run them.
+- Avoid micromanaging: only use direct wheel commands in emergencies when autonomy is clearly stuck.
+- Keep safety first—bump/cliff alerts or low battery mean you should change plans, pause, or seek the dock.
+
+## Command Palette
+Use bracketed commands exactly as written, each on its own line. Pair them with a brief narrative sentence before the commands.
+
+- `[new_goal <text>]` — Replace the current mission queue with a fresh objective (e.g., `[new_goal Explore the bright doorway and scan for paths back.]`).
+- `[mission <directive>]` — Add or modify planner steps without clearing the whole queue. Describe what to queue in plain language and include timing if helpful ("pause for 10 seconds", "then wall follow left for 20 seconds").
+- `[set_behavior <name> [key=value|flags]]` — Immediately push the behavior manager into a specific state (e.g., `[set_behavior scan cycles=4 turnSize=45]`). Use sparingly for urgent overrides.
+- `[say "<message>"]` — Have the rover speak to nearby humans; keep it short and friendly.
+- `[manual_move <action> <value>]` or `[forward|backward|left|right <value>]` — Emergency nudges only. If you issue one, explain why autonomy needed help.
+
+## Response Format
+1. One or two lively sentences that explain what you noticed and the strategic choice you’re making.
+2. 1–3 bracketed commands on separate lines (no more than one manual move per response).
+3. If you have nothing new to command, explicitly queue a short pause mission or confirm idle rather than staying silent.
+
+Stay curious, keep things upbeat, and make sure every directive has a purpose the autonomy stack can execute.

--- a/public/index.html
+++ b/public/index.html
@@ -365,6 +365,27 @@
                     </div>
 
                 <p class="font-semibold text-center" id="goal-text">Current Goal:</p>
+                <div class="grid grid-cols-1 lg:grid-cols-3 gap-2 mt-2" id="autonomy-status">
+                    <div class="bg-gray-600 rounded-xl p-2 flex flex-col gap-1">
+                        <p class="text-sm font-semibold text-blue-300">Behavior Brain</p>
+                        <p class="text-sm" id="behavior-current">Disabled</p>
+                        <p class="text-xs text-gray-300" id="behavior-reflex">Last reflex: none</p>
+                        <p class="text-xs text-gray-300" id="behavior-manual">Manual override: none</p>
+                        <p class="text-xs text-gray-400" id="behavior-details">No additional details</p>
+                    </div>
+                    <div class="bg-gray-600 rounded-xl p-2 flex flex-col gap-1">
+                        <p class="text-sm font-semibold text-blue-300">Mission Planner</p>
+                        <p class="text-sm" id="mission-active">Idle</p>
+                        <p class="text-xs text-gray-300" id="mission-goal">Goal: none</p>
+                        <ul class="text-xs text-gray-400 list-disc ml-4 space-y-1" id="mission-queue">
+                            <li>Queue empty</li>
+                        </ul>
+                    </div>
+                    <div class="bg-gray-600 rounded-xl p-2 flex flex-col gap-1">
+                        <p class="text-sm font-semibold text-blue-300">World Model</p>
+                        <p class="text-xs text-gray-300" id="world-summary">Awaiting sensor updates...</p>
+                    </div>
+                </div>
                 <p id="ollama-response-text" class="text-xs p-1 bg-gray-600 rounded-xl h-40 overflow-scroll">Ollama response here</p>
             </div>
             

--- a/roombaCommands.js
+++ b/roombaCommands.js
@@ -180,6 +180,10 @@ class RoombaController extends EventEmitter {
       this.emit('roomba:queue-empty');
     }
   }
+
+  isBusy() {
+    return this.busy || this.queue.length > 0;
+  }
 }
 
 // module.exports = RoombaController;


### PR DESCRIPTION
## Summary
- introduce a local autonomy stack with WorldModel, BehaviorManager, and MissionPlanner modules that track sensors, plan missions, and steer the robot
- refactor the Ollama control loop to use high-level goals/behaviors, stream new status summaries, and expose telemetry for the UI
- update the server and web client to broadcast and display behavior, mission, and world model state, plus add controller stop/clear helpers

## Testing
- not run (hardware dependent)


------
https://chatgpt.com/codex/tasks/task_e_68ca107ccfc48327b034b1e0528d06be