### PR TITLE
Add Discord snapshot sharing with Ollama captions

### DIFF
--- a/prompts/discord-caption.txt
+++ b/prompts/discord-caption.txt
@@ -1,0 +1,1 @@
+You are the onboard storyteller for a mischievous little roomba rover. Whenever you are given an image, respond with a single vivid sentence (max 200 characters) that captures what the camera sees right now. Keep the tone playful but clear so humans in Discord immediately understand the scene.

--- a/public/index.html
+++ b/public/index.html
@@ -368,10 +368,25 @@
                 <p id="ollama-response-text" class="text-xs p-1 bg-gray-600 rounded-xl h-40 overflow-scroll">Ollama response here</p>
             </div>
             
+            <div class="rounded-xl shadow-md p-1 bg-gray-700" id="discord-snapshot-card">
+                <p class="text-lg font-semibold text-center">Discord Snapshot</p>
+                <div class="flex flex-col gap-2 mt-2">
+                    <p class="text-sm text-gray-300 text-center">Share the latest camera peek with our Discord pals.</p>
+                    <select id="discord-channel-select" class="bg-gray-600 rounded-xl p-2 text-sm text-white disabled:opacity-50 disabled:cursor-not-allowed" disabled>
+                        <option value="">Connect to load channels</option>
+                    </select>
+                    <div class="flex gap-2">
+                        <button id="discord-refresh-button" class="btn bg-blue-500 flex-1 text-xs" disabled>Refresh Channels</button>
+                        <button id="discord-send-button" class="btn bg-indigo-500 flex-1" disabled>Send Snapshot</button>
+                    </div>
+                    <p id="discord-status-text" class="text-xs text-center text-gray-300">Waiting for connection…</p>
+                </div>
+            </div>
+
             <div class="rounded-xl shadow-md p-1 bg-gray-700">
                 <p class="text-lg font-semibold text-center">Wall Following Mode</p>
-                
-                
+
+
             </div>
 
             <!-- logs card -->


### PR DESCRIPTION
## Summary
- add backend support to list Discord channels and send camera snapshots with Ollama-generated captions
- expose a new Discord Snapshot panel in the UI that lets operators refresh channel list and share snapshots
- add a prompt used to generate playful Discord captions

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ccc5d5f9d88327981eff7e486d61ba