### PR TITLE
Add UI and backend to share Discord camera clips

### DIFF
--- a/CameraStream.js
+++ b/CameraStream.js
@@ -1,9 +1,11 @@
 const { spawn } = require('child_process');
+const { EventEmitter } = require('events');
 
 var latestFrontFrame = null;
 
-class CameraStream {
+class CameraStream extends EventEmitter {
     constructor(io, cameraId, devicePath, options = {}) {
+        super();
         this.io = io;
         this.cameraId = cameraId;
         this.devicePath = devicePath;
@@ -48,6 +50,7 @@ class CameraStream {
                 const frame = frameBuffer.slice(start, end + 2);
                 frameBuffer = frameBuffer.slice(end + 2);
                 this.latestFrame = frame;
+                this.emit('frame', frame);
             }
         });
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Control a 600 series roomba, or an IRobot Create 2 through a web browser
 - Live audio from the server's microphone
 - WASD control for desktop
 - On-screen joystick for mobile
+- One-click Discord clip sharing to any "general" channel you fancy
 
 
 Designed for an SBC, like a Raspberry Pi to be attached to the Roomba, and to use an Arduino Uno for Serial and the BRC keep-alive pulse, so the Roomba doesn't go into sleep mode.

--- a/public/index.html
+++ b/public/index.html
@@ -115,6 +115,10 @@
                     <!-- </div> -->
 
                     <p id="connectstatus" class="absolute top-3 left-3 rounded-full bg-red-500 bg-green-500 p-2 opacity-50">Disconnected</p>
+                    <div id="discord-recording-indicator" class="hidden absolute top-14 left-3 flex items-center gap-1 bg-red-600 bg-opacity-80 px-2 py-1 rounded-full text-xs font-bold uppercase tracking-wider shadow-lg z-30" title="Discord clip recording in progress">
+                        <span class="inline-block w-2 h-2 bg-white rounded-full animate-pulse"></span>
+                        <span>REC</span>
+                    </div>
                     <video id="localcam" class="absolute top-3 left-1/2 rounded-md w-40" autoplay muted></video>
 
                     <div class="absolute flex gap-1 top-3 transform left-1/2 -translate-x-1/2 left-3 bg-gray-500 p-1 rounded-xl opacity-50 items-center content-center">

--- a/public/index.html
+++ b/public/index.html
@@ -319,7 +319,21 @@
 
                 </div>
 
-            
+
+            </div>
+
+            <div class="rounded-xl shadow-md p-1 bg-gray-700" id="discord-clip-card">
+                <p class="text-lg font-semibold text-center">Discord Clips</p>
+                <div class="flex flex-col gap-1">
+                    <div class="flex gap-1">
+                        <select id="discord-channel-select" class="flex-1 bg-gray-600 rounded-xl p-1 text-sm md:text-base" disabled>
+                            <option value="" selected>Connect to load channels…</option>
+                        </select>
+                        <button id="discord-refresh-button" type="button" class="btn bg-blue-500 flex-shrink-0">Refresh</button>
+                    </div>
+                    <button id="discord-clip-button" type="button" class="btn bg-purple-500">Send 5s Clip</button>
+                    <p id="discord-clip-status" class="text-sm text-center text-gray-300"></p>
+                </div>
             </div>
 
             <div class="rounded-xl shadow-md p-1 bg-gray-700 hidden" id="ollama-panel">

--- a/public/main.js
+++ b/public/main.js
@@ -42,6 +42,7 @@ dropRight: document.getElementById('drop-right'),
     discordClipStatus: document.getElementById('discord-clip-status'),
     discordClipButton: document.getElementById('discord-clip-button'),
     discordRefreshButton: document.getElementById('discord-refresh-button'),
+    discordRecordingIndicator: document.getElementById('discord-recording-indicator'),
 // wallSignal: document.getElementById('wall-distance')
 };
 
@@ -568,6 +569,14 @@ socket.on('discordClipStatus', payload => {
 
     const working = status === 'recording' || status === 'uploading';
     const hasChannels = discordChannelMap.size > 0;
+
+    if (dom.discordRecordingIndicator) {
+        if (status === 'recording') {
+            dom.discordRecordingIndicator.classList.remove('hidden');
+        } else {
+            dom.discordRecordingIndicator.classList.add('hidden');
+        }
+    }
 
     if (dom.discordClipButton) {
         dom.discordClipButton.disabled = working || !hasChannels;


### PR DESCRIPTION
## Summary
- add a Discord clip card in the web UI with channel picker and send button
- extend the Socket.IO server to record a short ffmpeg clip and upload it to a selected Discord "general" channel
- expose helper utilities in the Discord bot for listing general channels and sending clip uploads

## Testing
- `node --check server.js`
- `node --check discordBot.js`
- `node --check public/main.js`


------
https://chatgpt.com/codex/tasks/task_e_68cccce4f0248327a2c044ecc5228a6b